### PR TITLE
Write nobody user as numeric to be compatible with runAsNonRoot

### DIFF
--- a/init-container/Containerfile.debian
+++ b/init-container/Containerfile.debian
@@ -3,6 +3,6 @@ FROM --platform=$BUILDPLATFORM debian:stable@sha256:37ad77961af28800b00f5f96a4df
 RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
-USER nobody
+USER 65534
 COPY entrypoint-debian.sh /entrypoint
 ENTRYPOINT [ "/entrypoint" ]

--- a/init-container/Containerfile.redhat
+++ b/init-container/Containerfile.redhat
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM redhat/ubi10-minimal:10.1@sha256:7bd3d2e7f5c507aebd1575d0f2fab9fe3e882e25fee54fa07f7970aa8bbc5fab
 
-USER nobody
+USER 65534
 COPY entrypoint-redhat.sh /entrypoint
 ENTRYPOINT [ "/entrypoint" ]


### PR DESCRIPTION
Cain init containers are now running as nonRoot, but in k8s apparently user must be numeric to be compatible with runAsNonRoot. See the error message I'm now getting:

```
 Warning  Failed                  7s (x2 over 8s)    kubelet                  spec.initContainers{ca-cert-gen}: Error: container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root (pod: "xxxxx-85d5f9d5bb-d99x5_yyyyyy(f9347b3b-84ce-4f6b-a540-28d3dd19a945)", container: ca-cert-gen)
```

This MR simply changes the `USER nobody` to `USER 65534`.